### PR TITLE
Increase SourceForge rss feed limit

### DIFF
--- a/src/main/kotlin/com/bnorm/robocode/sf/SourceForge.kt
+++ b/src/main/kotlin/com/bnorm/robocode/sf/SourceForge.kt
@@ -14,7 +14,7 @@ internal object SourceForge {
         registerModule(KotlinModule())
     }
 
-    private const val SOURCEFORGE_ROBOCODE_RSS = "https://sourceforge.net/projects/robocode/rss?limit=1"
+    private const val SOURCEFORGE_ROBOCODE_RSS = "https://sourceforge.net/projects/robocode/rss?limit=2"
     private val ROBOCODE_FILE_REGEX = "/robocode/([0-9.]+)/robocode-([0-9.]+)-setup.jar".toRegex()
 
     private fun downloadLink(version: String) =


### PR DESCRIPTION
Newly released version broke robocodeDownload task, because robocode-1.9.4.2-setup.jar is now second item in feed: https://sourceforge.net/projects/robocode/rss